### PR TITLE
Removed call to populateGamesMenu in ManageLayout

### DIFF
--- a/Source/ManageLayout.cpp
+++ b/Source/ManageLayout.cpp
@@ -16,7 +16,6 @@ namespace ui
         this->Add(this->gamesMenu);
         this->Add(this->amiiboMenu);
         this->SetElementOnFocus(this->gamesMenu);
-        populateGamesMenu();
         this->SetOnInput(std::bind(&ManageLayout::manage_Input, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
     }
 


### PR DESCRIPTION
populateGamesMenu() is calling GetAmiibos() which tries to read settings.txt which hasn't been created or is blank at that point in code.